### PR TITLE
Add TDT recording pipeline (base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ From a terminal (note that conda should install one in your system) you can do t
 git clone https://github.com/catalystneuro/turner-lab-to-nwb
 cd turner-lab-to-nwb
 conda env create --file make_env.yml
-conda activate turner-lab-to-nwb-env
+conda activate turner_lab_to_nwb_env
 ```
 
 This creates a [conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/environments.html) which isolates the conversion code from your system libraries.  We recommend that you run all your conversion related tasks and analysis from the created environment in order to minimize issues related to package dependencies.

--- a/src/turner_lab_to_nwb/asap_tdt/__init__.py
+++ b/src/turner_lab_to_nwb/asap_tdt/__init__.py
@@ -1,0 +1,1 @@
+from .asap_tdtnwbconverter import AsapTdtNWBConverter

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_all_sessions.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_all_sessions.py
@@ -1,0 +1,73 @@
+import os
+from pathlib import Path
+
+import numpy as np
+from neuroconv.tools import LocalPathExpander
+
+from turner_lab_to_nwb.asap_tdt.asap_tdt_convert_session import session_to_nwb
+from turner_lab_to_nwb.asap_tdt.utils import load_session_metadata
+
+
+# The root folder containing the sessions
+folder_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample")
+# The output folder for the NWB files
+output_dir_path = folder_path / "nwbfiles"
+os.makedirs(output_dir_path, exist_ok=True)
+
+# The path to the electrode metadata file (.xlsx)
+data_list_file_path = folder_path / "Isis_DataList_temp.xlsx"
+stub_test = False  # Set to False to convert the full session, otherwise only a stub will be converted for testing
+verbose = True
+
+# Specify source data (note this assumes the files are arranged in the same way as in the example data)
+source_data_spec = {
+    "recording": {
+        "base_directory": folder_path,
+        "file_path": "I_{date_string}/{subject_id}_{session_id}.Tbk",
+    }
+}
+
+# Instantiate LocalPathExpander
+path_expander = LocalPathExpander()
+
+# Expand paths and extract metadata
+metadata_list = path_expander.expand_paths(source_data_spec)
+
+for index, metadata in enumerate(metadata_list):
+    date_string = metadata["metadata"]["extras"]["date_string"]
+    subject_id = metadata["metadata"]["Subject"]["subject_id"]
+    session_id = metadata["metadata"]["NWBFile"]["session_id"]
+    print(f"Converting session {session_id} of subject {subject_id} ...")
+
+    nwbfile_name = f"{subject_id}_{session_id}.nwb"
+    if stub_test:
+        nwbfile_name = f"stub_{subject_id}_{session_id}.nwb"
+
+    session_metadata = load_session_metadata(file_path=data_list_file_path, session_id=session_id)
+    plexon_data = session_metadata.groupby("Area")["Chan#"].first().reset_index()
+
+    stim_site = session_metadata["Stim. site"].replace(np.nan, None).unique().tolist()[0]
+
+    vl_plexon_first_channel = plexon_data.loc[plexon_data["Area"] == "VLa", "Chan#"].values[0]
+    vl_plexon_file_path = list(
+        folder_path.rglob(f"I_{date_string}/{session_id}_Chans_{vl_plexon_first_channel}_*.plx")
+    )[0]
+
+    if stim_site is None:
+        gpi_plexon_first_channel = plexon_data.loc[plexon_data["Area"] == "GPi", "Chan#"].values[0]
+        gpi_plexon_file_path = list(
+            folder_path.rglob(f"I_{date_string}/{session_id}_Chans_{gpi_plexon_first_channel}_*.plx")
+        )[0]
+    else:
+        # If stimulation site is GPi, we only have spike sorting date from VL region, the plexon file for GPi is empty
+        gpi_plexon_file_path = None
+
+    session_to_nwb(
+        tdt_tank_file_path=metadata["source_data"]["recording"]["file_path"],
+        nwbfile_path=output_dir_path / nwbfile_name,
+        data_list_file_path=data_list_file_path,
+        vl_plexon_file_path=vl_plexon_file_path,
+        gpi_plexon_file_path=gpi_plexon_file_path,
+        session_id=session_id,
+        stub_test=stub_test,
+    )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -10,8 +10,10 @@ from turner_lab_to_nwb.asap_tdt import AsapTdtNWBConverter
 
 def session_to_nwb(
     nwbfile_path: FilePathType,
-    tdt_file_path: FilePathType,
-    electrode_metadata_file_path: FilePathType,
+    tdt_tank_file_path: FilePathType,
+    data_list_file_path: FilePathType,
+    VL_plexon_file_path: FilePathType,
+    GPi_plexon_file_path: FilePathType,
     stub_test: bool = False,
 ):
     """
@@ -19,27 +21,37 @@ def session_to_nwb(
     ----------
     nwbfile_path : FilePathType
         The path that points to the NWB file to be created.
-    tdt_file_path : FilePathType
+    tdt_tank_file_path : FilePathType
         The path that points to a TDT Tank file (.Tbk).
-    electrode_metadata_file_path : FilePathType
+    data_list_file_path : FilePathType
         The path that points to the electrode metadata file (.xlsx).
     stub_test : bool, optional
         Whether to run the conversion in stub test mode, by default False.
     """
-    ecephys_file_path = Path(tdt_file_path)
+    ecephys_file_path = Path(tdt_tank_file_path)
 
     source_data = dict()
     conversion_options = dict()
 
     # Add Recording
     source_data.update(
-        dict(
-            Recording=dict(
-                file_path=str(ecephys_file_path), electrode_metadata_file_path=str(electrode_metadata_file_path)
-            )
-        )
+        dict(Recording=dict(file_path=str(ecephys_file_path), electrode_metadata_file_path=str(data_list_file_path)))
     )
     conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
+
+    # Add Sorting
+    source_data.update(
+        dict(
+            SortingVL=dict(file_path=str(VL_plexon_file_path)),
+            SortingGPi=dict(file_path=str(GPi_plexon_file_path)),
+        )
+    )
+    conversion_options.update(
+        dict(
+            SortingVL=dict(stub_test=stub_test),
+            SortingGPi=dict(stub_test=stub_test),
+        )
+    )
 
     converter = AsapTdtNWBConverter(source_data=source_data)
 
@@ -63,14 +75,22 @@ def session_to_nwb(
 
 if __name__ == "__main__":
     # Parameters for conversion
-    tank_file_path = Path("/Users/weian/data/Previous_PD_Project_sample/I_160615/Gaia_I_160615_1.Tbk")
-    electrode_metadata_excel_file_path = Path("/Users/weian/data/Previous_PD_Project_sample/Isis_DataList_160615.xlsx")
+    folder_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/I_160615")
+
+    tank_file_path = folder_path / "Gaia_I_160615_1.Tbk"
+    data_list_file_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/Isis_DataList_160615.xlsx")
+
+    VL_plexon_file_path = folder_path / "I_160615_1_Chans_1_1.plx"
+    GPi_plexon_file_path = folder_path / "I_160615_1_Chans_17_32.plx"
+
     nwbfile_path = Path("/Volumes/t7-ssd/nwbfiles/stub_Gaia_I_160615_1.nwb")
     stub_test = True
 
     session_to_nwb(
         nwbfile_path=nwbfile_path,
-        tdt_file_path=tank_file_path,
-        electrode_metadata_file_path=electrode_metadata_excel_file_path,
+        tdt_tank_file_path=tank_file_path,
+        data_list_file_path=data_list_file_path,
+        VL_plexon_file_path=VL_plexon_file_path,
+        GPi_plexon_file_path=GPi_plexon_file_path,
         stub_test=stub_test,
     )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -1,0 +1,76 @@
+"""Primary script to run to convert an entire session for of data using the NWBConverter."""
+from pathlib import Path
+import datetime
+from zoneinfo import ZoneInfo
+
+from neuroconv.utils import load_dict_from_file, dict_deep_update, FilePathType
+
+from turner_lab_to_nwb.asap_tdt import AsapTdtNWBConverter
+
+
+def session_to_nwb(
+    nwbfile_path: FilePathType,
+    tdt_file_path: FilePathType,
+    electrode_metadata_file_path: FilePathType,
+    stub_test: bool = False,
+):
+    """
+    Parameters
+    ----------
+    nwbfile_path : FilePathType
+        The path that points to the NWB file to be created.
+    tdt_file_path : FilePathType
+        The path that points to a TDT Tank file (.Tbk).
+    electrode_metadata_file_path : FilePathType
+        The path that points to the electrode metadata file (.xlsx).
+    stub_test : bool, optional
+        Whether to run the conversion in stub test mode, by default False.
+    """
+    ecephys_file_path = Path(tdt_file_path)
+
+    source_data = dict()
+    conversion_options = dict()
+
+    # Add Recording
+    source_data.update(
+        dict(
+            Recording=dict(
+                file_path=str(ecephys_file_path), electrode_metadata_file_path=str(electrode_metadata_file_path)
+            )
+        )
+    )
+    conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
+
+    converter = AsapTdtNWBConverter(source_data=source_data)
+
+    metadata = converter.get_metadata()
+    metadata["NWBFile"].update(
+        session_id=ecephys_file_path.stem.replace("_", "-"),
+        # todo: add session_start_time to metadata
+        session_start_time=datetime.datetime.now(tz=ZoneInfo("US/Pacific")),
+    )
+
+    # Update default metadata with the editable in the corresponding yaml file
+    editable_metadata_path = Path(__file__).parent / "asap_tdt_metadata.yaml"
+    editable_metadata = load_dict_from_file(editable_metadata_path)
+    metadata = dict_deep_update(metadata, editable_metadata)
+
+    # Run conversion
+    converter.run_conversion(
+        metadata=metadata, nwbfile_path=nwbfile_path, conversion_options=conversion_options, overwrite=True
+    )
+
+
+if __name__ == "__main__":
+    # Parameters for conversion
+    tank_file_path = Path("/Users/weian/data/Previous_PD_Project_sample/I_160615/Gaia_I_160615_1.Tbk")
+    electrode_metadata_excel_file_path = Path("/Users/weian/data/Previous_PD_Project_sample/Isis_DataList_160615.xlsx")
+    nwbfile_path = Path("/Volumes/t7-ssd/nwbfiles/stub_Gaia_I_160615_1.nwb")
+    stub_test = True
+
+    session_to_nwb(
+        nwbfile_path=nwbfile_path,
+        tdt_file_path=tank_file_path,
+        electrode_metadata_file_path=electrode_metadata_excel_file_path,
+        stub_test=stub_test,
+    )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -13,9 +13,13 @@ def session_to_nwb(
     data_list_file_path: FilePathType,
     vl_plexon_file_path: FilePathType,
     gpi_plexon_file_path: FilePathType,
+    session_id: str,
+    stim_site: str,
     stub_test: bool = False,
 ):
     """
+    Convert a session of data to NWB.
+
     Parameters
     ----------
     nwbfile_path : FilePathType
@@ -28,6 +32,10 @@ def session_to_nwb(
         The path to Plexon file (.plx) containing the spike sorted data from VL.
     gpi_plexon_file_path : FilePathType
         The path to Plexon file (.plx) containing the spike sorted data from GPi.
+    session_id : str
+        The unique identifier for the session.
+    stim_site : str
+        The name of the stimulation site (either None or "GPi").
     stub_test : bool, optional
         Whether to run the conversion in stub test mode, by default False.
     """
@@ -38,32 +46,38 @@ def session_to_nwb(
 
     # Add Recording
     source_data.update(
-        dict(Recording=dict(file_path=str(ecephys_file_path), electrode_metadata_file_path=str(data_list_file_path)))
+        dict(Recording=dict(file_path=str(ecephys_file_path), data_list_file_path=str(data_list_file_path)))
     )
     conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
 
     # Add Sorting
-    source_data.update(
-        dict(
-            SortingVL=dict(file_path=str(vl_plexon_file_path)),
-            SortingGPi=dict(file_path=str(gpi_plexon_file_path)),
-        )
+    conversion_options_sorting = dict(
+        stub_test=stub_test,
+        write_as="processing",
+        units_description="The units were sorted using the Plexon Offline Sorter v3.",
     )
-    conversion_options.update(
-        dict(
-            SortingVL=dict(stub_test=stub_test),
-            SortingGPi=dict(stub_test=stub_test),
+    if stim_site is None:
+        source_data.update(
+            dict(
+                SortingVL=dict(file_path=str(vl_plexon_file_path)),
+                SortingGPi=dict(file_path=str(gpi_plexon_file_path)),
+            )
         )
-    )
+        conversion_options.update(dict(SortingVL=conversion_options_sorting, SortingGPi=conversion_options_sorting))
+    # If stimulation site is GPi, we only have spike sorting date from VL region, the plexon file for GPi is empty
+    elif stim_site == "GPi":
+        source_data.update(dict(SortingVL=dict(file_path=str(vl_plexon_file_path))))
+        conversion_options.update(dict(SortingVL=conversion_options_sorting))
 
     converter = AsapTdtNWBConverter(source_data=source_data)
 
     metadata = converter.get_metadata()
     # For data provenance we can add the time zone information to the conversion if missing
+
     session_start_time = metadata["NWBFile"]["session_start_time"]
     tzinfo = tz.gettz("US/Pacific")
     metadata["NWBFile"].update(
-        session_id=ecephys_file_path.stem.replace("_", "-"),
+        session_id=str(session_id).replace("_", "-"),
         session_start_time=session_start_time.replace(tzinfo=tzinfo),
     )
 
@@ -80,16 +94,33 @@ def session_to_nwb(
 
 if __name__ == "__main__":
     # Parameters for conversion
-    folder_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/I_160615")
+    # The root folder containing the sessions
+    folder_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample")
 
-    tank_file_path = folder_path / "Gaia_I_160615_2.Tbk"
+    # The date string that identifies the session
+    date_string = "160624"
+    # The identifier of the session to be converted
+    session_id = f"I_{date_string}_2"
+
+    # The path to a single TDT Tank file (.Tbk)
+    tank_file_path = folder_path / f"I_{date_string}" / f"Gaia_{session_id}.Tbk"
+
+    # The path to the electrode metadata file (.xlsx)
     data_list_file_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/Isis_DataList_temp.xlsx")
 
-    vl_plexon_file_path = folder_path / "I_160615_2_Chans_1_1.plx"
-    gpi_plexon_file_path = folder_path / "I_160615_2_Chans_17_32.plx"
+    # The plexon file with the spike sorted data from VL
+    vl_plexon_file_path = folder_path / f"I_{date_string}" / f"{session_id}_Chans_1_16.plx"
+    # The plexon file with the spike sorted data from GPi
+    gpi_plexon_file_path = folder_path / f"I_{date_string}" / f"{session_id}_Chans_24_24.plx"
 
-    nwbfile_path = Path("/Volumes/t7-ssd/nwbfiles/stub_Gaia_I_160615_2.nwb")
-    stub_test = True
+    # The name of the stimulation site (either None or "GPi")
+    stim_site = "GPi"
+
+    # The path to the NWB file to be created
+    nwbfile_path = Path(f"/Volumes/t7-ssd/nwbfiles/stub_Gaia_{session_id}.nwb")
+
+    # For testing purposes, set stub_test to True to convert only a stub of the session
+    stub_test = False
 
     session_to_nwb(
         nwbfile_path=nwbfile_path,
@@ -97,5 +128,7 @@ if __name__ == "__main__":
         data_list_file_path=data_list_file_path,
         vl_plexon_file_path=vl_plexon_file_path,
         gpi_plexon_file_path=gpi_plexon_file_path,
+        session_id=session_id,
+        stim_site=stim_site,
         stub_test=stub_test,
     )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         nwbfile_path=nwbfile_path,
         tdt_tank_file_path=tank_file_path,
         data_list_file_path=data_list_file_path,
-        VL_plexon_file_path=vl_plexon_file_path,
-        GPi_plexon_file_path=gpi_plexon_file_path,
+        vl_plexon_file_path=vl_plexon_file_path,
+        gpi_plexon_file_path=gpi_plexon_file_path,
         stub_test=stub_test,
     )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -1,8 +1,7 @@
 """Primary script to run to convert an entire session for of data using the NWBConverter."""
 from pathlib import Path
-import datetime
-from zoneinfo import ZoneInfo
 
+from dateutil.tz import tz
 from neuroconv.utils import load_dict_from_file, dict_deep_update, FilePathType
 
 from turner_lab_to_nwb.asap_tdt import AsapTdtNWBConverter
@@ -56,10 +55,12 @@ def session_to_nwb(
     converter = AsapTdtNWBConverter(source_data=source_data)
 
     metadata = converter.get_metadata()
+    # For data provenance we can add the time zone information to the conversion if missing
+    session_start_time = metadata["NWBFile"]["session_start_time"]
+    tzinfo = tz.gettz("US/Pacific")
     metadata["NWBFile"].update(
         session_id=ecephys_file_path.stem.replace("_", "-"),
-        # todo: add session_start_time to metadata
-        session_start_time=datetime.datetime.now(tz=ZoneInfo("US/Pacific")),
+        session_start_time=session_start_time.replace(tzinfo=tzinfo),
     )
 
     # Update default metadata with the editable in the corresponding yaml file

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -11,8 +11,8 @@ def session_to_nwb(
     nwbfile_path: FilePathType,
     tdt_tank_file_path: FilePathType,
     data_list_file_path: FilePathType,
-    VL_plexon_file_path: FilePathType,
-    GPi_plexon_file_path: FilePathType,
+    vl_plexon_file_path: FilePathType,
+    gpi_plexon_file_path: FilePathType,
     stub_test: bool = False,
 ):
     """
@@ -24,6 +24,10 @@ def session_to_nwb(
         The path that points to a TDT Tank file (.Tbk).
     data_list_file_path : FilePathType
         The path that points to the electrode metadata file (.xlsx).
+    vl_plexon_file_path : FilePathType
+        The path to Plexon file (.plx) containing the spike sorted data from VL.
+    gpi_plexon_file_path : FilePathType
+        The path to Plexon file (.plx) containing the spike sorted data from GPi.
     stub_test : bool, optional
         Whether to run the conversion in stub test mode, by default False.
     """
@@ -41,8 +45,8 @@ def session_to_nwb(
     # Add Sorting
     source_data.update(
         dict(
-            SortingVL=dict(file_path=str(VL_plexon_file_path)),
-            SortingGPi=dict(file_path=str(GPi_plexon_file_path)),
+            SortingVL=dict(file_path=str(vl_plexon_file_path)),
+            SortingGPi=dict(file_path=str(gpi_plexon_file_path)),
         )
     )
     conversion_options.update(
@@ -78,20 +82,20 @@ if __name__ == "__main__":
     # Parameters for conversion
     folder_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/I_160615")
 
-    tank_file_path = folder_path / "Gaia_I_160615_1.Tbk"
+    tank_file_path = folder_path / "Gaia_I_160615_2.Tbk"
     data_list_file_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/Isis_DataList_temp.xlsx")
 
-    VL_plexon_file_path = folder_path / "I_160615_1_Chans_1_1.plx"
-    GPi_plexon_file_path = folder_path / "I_160615_1_Chans_17_32.plx"
+    vl_plexon_file_path = folder_path / "I_160615_2_Chans_1_1.plx"
+    gpi_plexon_file_path = folder_path / "I_160615_2_Chans_17_32.plx"
 
-    nwbfile_path = Path("/Volumes/t7-ssd/nwbfiles/stub_Gaia_I_160615_1.nwb")
+    nwbfile_path = Path("/Volumes/t7-ssd/nwbfiles/stub_Gaia_I_160615_2.nwb")
     stub_test = True
 
     session_to_nwb(
         nwbfile_path=nwbfile_path,
         tdt_tank_file_path=tank_file_path,
         data_list_file_path=data_list_file_path,
-        VL_plexon_file_path=VL_plexon_file_path,
-        GPi_plexon_file_path=GPi_plexon_file_path,
+        VL_plexon_file_path=vl_plexon_file_path,
+        GPi_plexon_file_path=gpi_plexon_file_path,
         stub_test=stub_test,
     )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     folder_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/I_160615")
 
     tank_file_path = folder_path / "Gaia_I_160615_1.Tbk"
-    data_list_file_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/Isis_DataList_160615.xlsx")
+    data_list_file_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/Isis_DataList_temp.xlsx")
 
     VL_plexon_file_path = folder_path / "I_160615_1_Chans_1_1.plx"
     GPi_plexon_file_path = folder_path / "I_160615_1_Chans_17_32.plx"

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_metadata.yaml
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_metadata.yaml
@@ -5,3 +5,11 @@ NWBFile:
   lab: Turner
   experimenter:
     - Kase, Daisuke
+Ecephys:
+  UnitProperties:
+    - name: unit_quality
+      description: The quality metric for each unit.
+    - name: unit_quality_post_sorting
+      description: The quality of the unit after sorting.
+    - name: good_period
+      description: The period when the spike waveforms had good isolation.

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_metadata.yaml
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_metadata.yaml
@@ -1,0 +1,7 @@
+NWBFile:
+  session_description:
+    A rich text description of the experiment. Can also just be the abstract of the publication.
+  institution: University of Pittsburgh
+  lab: Turner
+  experimenter:
+    - Kase, Daisuke

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md
@@ -1,0 +1,30 @@
+# Notes concerning the asap_tdt conversion
+
+## TDT session folder structure
+
+Each TDT folder contains two sessions (e.g. `I_160615` and `I_160615_2`).
+The continuous data for each session is stored in Tucker Davis format (`.Tbk`). The unfiltered data is stored
+in `.ddt` files and the filtered data is stored in `.flt.mat` files. The `.plx` files contain the spike sorting data from Plexon Offline Sorter v3.
+
+Example folder structure:
+
+    I_160615/
+    ├── Gaia_I_160615_1.Tbk
+    ├── ...
+    ├── Gaia_I_160615_2.Tbk
+    ├── ...
+    ├── I_160615_1.mat
+    ├── I_160615_1_Chans_1_1.ddt
+    ├── I_160615_1_Chans_1_1.flt.mat
+    ├── I_160615_1_Chans_1_1.mat
+    ├── I_160615_1_Chans_1_1.plx
+    ├── I_160615_1_Chans_17_32.ddt
+    ├── I_160615_1_Chans_17_32.flt.mat
+    ├── I_160615_1_Chans_17_32.mat
+    ├── I_160615_1_Chans_17_32.plx
+    ├── ...
+    └── I_160615_2.mat
+
+## TDT to NWB mapping
+
+TODO: add UML diagram

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md
@@ -1,5 +1,16 @@
 # Notes concerning the asap_tdt conversion
 
+## Experiment notes
+
+Based on the [manuscript](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.3000829) provided by the lab, the experiment was performed as follows:
+
+Extracellular spiking activity of neurons in globus pallidus-internus (GPi) and ventrolateral anterior nucleus (VLa) was recorded using multiple glass-insulated tungsten microelectrodes (0.5–1.5 MΩ, Alpha Omega)
+or 16-contact linear probes (0.5–1.0 MΩ, V-probe, Plexon) in monkeys while performing a choice reaction time reaching task.
+During a subset of data collection sessions, EMG activity was collected via either chronically implanted subcutaneous electrodes or electrodes inserted percutaneously immediately before the session.
+All recordings were performed with at least one electrode positioned in each of GPi and VLa.
+Some sessions also included stimulation of GPi using custom built stimulating electrodes implanted in the arm-related region of primary motor cortex and in the SCP at its decussation.
+The stored neuronal data were high-pass filtered (Fpass: 300 Hz, Matlab FIRPM) and thresholded, and candidate action potentials were sorted into clusters in principal components space (Off-line Sorter, Plexon).
+
 ## DataList spreadsheet
 
 The DataList spreadsheet contains information about the electrodes (e.g. the electrode number, the brain region, the depth, etc.)

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md
@@ -1,10 +1,15 @@
 # Notes concerning the asap_tdt conversion
 
+## DataList spreadsheet
+
+The DataList spreadsheet contains information about the electrodes (e.g. the electrode number, the brain region, the depth, etc.)
+and the sessions (the date, the task, whether stimulation was applied etc.).
+
 ## TDT session folder structure
 
-Each TDT folder contains two sessions (e.g. `I_160615` and `I_160615_2`).
-The continuous data for each session is stored in Tucker Davis format (`.Tbk`). The unfiltered data is stored
-in `.ddt` files and the filtered data is stored in `.flt.mat` files. The `.plx` files contain the spike sorting data from Plexon Offline Sorter v3.
+Each TDT folder contains two sessions (e.g. `I_160615_1` and `I_160615_2`).
+The continuous data for each session is stored in Tucker Davis format (with files of `.Tbk`, `.Tdx`, `.tev`, `.tnt`, `.tsq`). The raw data and the high-pass filtered data
+is stored in `.ddt` and `.flt.mat` files. The `.plx` files contain the spike sorting data from Plexon Offline Sorter v3.
 
 Example folder structure:
 
@@ -24,6 +29,30 @@ Example folder structure:
     ├── I_160615_1_Chans_17_32.plx
     ├── ...
     └── I_160615_2.mat
+
+## Events data
+
+The events data is stored in `.mat` files (in a structure called `events`).
+
+| Event Name   | Description   |
+|--------------|---------------|
+| trialnum     | The identifier of the trial |
+| starttime    | The start time of the trial (sec) |
+| endtime      | The end time of the trial (sec) |
+| erroron      | The time of the error onset |
+| target       | The identifier of the target (1:left or 3:right in this task) |
+| rewardon     | The time of the reward onset |
+| rewardoff    | The time of the reward off |
+| mvt_onset    | The time of the hand sensor at the home-position off (= onset of the movement) |
+| mvt_end      | The time of the hand sensor at the reach target on (= end of the movement) |
+| return_onset | The time of the hand sensor at the reach target off (= onset of the return movement) |
+| return_end   | The time of the hand sensor at the home-position on (= end of the return movement) |
+| cue_onset    | The time of the target and go-cue instruction (reach target and go-cue were instructed simultaneously in this task) |
+
+## Stimulation data
+
+Some sessions may also include stimulation data which is stored in `.mat` files (in a structure called `dbs`).
+This data contains the onset times of stimulation. The site of stimulation and depth is stored in the `DataList` spreadsheet ("Stim. depth", "Stim. site").
 
 ## TDT to NWB mapping
 

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_requirements.txt
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_requirements.txt
@@ -1,0 +1,2 @@
+neuroconv[tdt,plexon]
+openpyxl==3.1.2

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -46,7 +46,10 @@ class AsapTdtNWBConverter(NWBConverter):
         )
 
         num_units = 0
-        for interface_name in ["SortingVL", "SortingGPi"]:
+        sorting_interfaces = [
+            interface_name for interface_name in self.data_interface_objects if "Sorting" in interface_name
+        ]
+        for interface_name in sorting_interfaces:
             target_name = interface_name.replace("Sorting", "")
             sorting_metadata = electrode_metadata[electrode_metadata["Target"] == target_name]
 

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from neuroconv import NWBConverter
 from neuroconv.datainterfaces import PlexonSortingInterface
+from neuroconv.utils import DeepDict
 from pynwb import NWBFile
 
 from turner_lab_to_nwb.asap_tdt.interfaces import ASAPTdtRecordingInterface
@@ -16,68 +17,79 @@ class AsapTdtNWBConverter(NWBConverter):
         SortingGPi=PlexonSortingInterface,
     )
 
-    def run_conversion(
-        self,
-        nwbfile_path: Optional[str] = None,
-        nwbfile: Optional[NWBFile] = None,
-        metadata: Optional[dict] = None,
-        overwrite: bool = False,
-        conversion_options: Optional[dict] = None,
-    ) -> None:
+    def get_metadata(self) -> DeepDict:
+        metadata = super().get_metadata()
 
-        # Rename unit properties to have descriptive names
-        unit_properties_mapping = {
-            "Area": "brain_area",
-            "Quality": "unit_quality",
-            "Quality (post-sorting)": "unit_quality_post_sorting",
-            "GoodPeriod": "good_period",
-        }
+        # Explicitly set session_start_time to recording start time
+        recording_interface = self.data_interface_objects["Recording"]
+        interface_metadata = recording_interface.get_metadata()
+        metadata["NWBFile"].update(session_start_time=interface_metadata["NWBFile"]["session_start_time"])
 
-        # Map unit quality values to more descriptive names
-        quality_values_map = dict(
-            A="excellent",
-            B="good",
-            C="not good enough to call single-unit",
-        )
-        electrode_metadata = self.data_interface_objects["Recording"]._electrode_metadata
-        electrode_metadata["Quality"] = electrode_metadata["Quality"].replace(quality_values_map)
-        electrode_metadata["Quality (post-sorting)"] = electrode_metadata["Quality (post-sorting)"].replace(
-            quality_values_map
-        )
+        return metadata
 
-        num_units = 0
-        sorting_interfaces = [
-            interface_name for interface_name in self.data_interface_objects if "Sorting" in interface_name
-        ]
-        for interface_name in sorting_interfaces:
-            target_name = interface_name.replace("Sorting", "")
-            sorting_metadata = electrode_metadata[electrode_metadata["Target"] == target_name]
 
-            sorting_interface = self.data_interface_objects[interface_name]
-            sorting_extractor = sorting_interface.sorting_extractor
+def run_conversion(
+    self,
+    nwbfile_path: Optional[str] = None,
+    nwbfile: Optional[NWBFile] = None,
+    metadata: Optional[dict] = None,
+    overwrite: bool = False,
+    conversion_options: Optional[dict] = None,
+) -> None:
 
-            if len(sorting_metadata) != sorting_extractor.get_num_units():
-                # TODO: how to deal with the fact that the Vla data has 2 units but only one of them in the metadata
-                area_value = sorting_metadata["Area"].values[0]
-                sorting_extractor.set_property(
-                    key="brain_area",
-                    values=[area_value] * sorting_extractor.get_num_units(),
-                )
-                continue
-            for property_name, renamed_property_name in unit_properties_mapping.items():
-                sorting_extractor.set_property(
-                    key=renamed_property_name,
-                    values=sorting_metadata[property_name].values.tolist(),
-                )
-            extractor_unit_ids = sorting_extractor.get_unit_ids()
-            # unit_ids are not unique across sorting interfaces, so we are offsetting them here
-            sorting_extractor._main_ids = extractor_unit_ids + num_units
-            num_units = len(extractor_unit_ids)
+    # Rename unit properties to have descriptive names
+    unit_properties_mapping = {
+        "Area": "brain_area",
+        "Quality": "unit_quality",
+        "Quality (post-sorting)": "unit_quality_post_sorting",
+        "GoodPeriod": "good_period",
+    }
 
-        super().run_conversion(
-            nwbfile_path=nwbfile_path,
-            nwbfile=nwbfile,
-            metadata=metadata,
-            overwrite=overwrite,
-            conversion_options=conversion_options,
-        )
+    # Map unit quality values to more descriptive names
+    quality_values_map = dict(
+        A="excellent",
+        B="good",
+        C="not good enough to call single-unit",
+    )
+    electrode_metadata = self.data_interface_objects["Recording"]._electrode_metadata
+    electrode_metadata["Quality"] = electrode_metadata["Quality"].replace(quality_values_map)
+    electrode_metadata["Quality (post-sorting)"] = electrode_metadata["Quality (post-sorting)"].replace(
+        quality_values_map
+    )
+
+    num_units = 0
+    sorting_interfaces = [
+        interface_name for interface_name in self.data_interface_objects if "Sorting" in interface_name
+    ]
+    for interface_name in sorting_interfaces:
+        target_name = interface_name.replace("Sorting", "")
+        sorting_metadata = electrode_metadata[electrode_metadata["Target"] == target_name]
+
+        sorting_interface = self.data_interface_objects[interface_name]
+        sorting_extractor = sorting_interface.sorting_extractor
+
+        if len(sorting_metadata) != sorting_extractor.get_num_units():
+            # TODO: how to deal with the fact that the Vla data has 2 units but only one of them in the metadata
+            area_value = sorting_metadata["Area"].values[0]
+            sorting_extractor.set_property(
+                key="brain_area",
+                values=[area_value] * sorting_extractor.get_num_units(),
+            )
+            continue
+        for property_name, renamed_property_name in unit_properties_mapping.items():
+            sorting_extractor.set_property(
+                key=renamed_property_name,
+                values=sorting_metadata[property_name].values.tolist(),
+            )
+        extractor_unit_ids = sorting_extractor.get_unit_ids()
+        # unit_ids are not unique across sorting interfaces, so we are offsetting them here
+        sorting_extractor._main_ids = extractor_unit_ids + num_units
+        num_units = len(extractor_unit_ids)
+
+    super().run_conversion(
+        nwbfile_path=nwbfile_path,
+        nwbfile=nwbfile,
+        metadata=metadata,
+        overwrite=overwrite,
+        conversion_options=conversion_options,
+    )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -25,20 +25,6 @@ class AsapTdtNWBConverter(NWBConverter):
         conversion_options: Optional[dict] = None,
     ) -> None:
 
-        recording_interface = self.data_interface_objects["Recording"]
-        electrode_metadata = recording_interface._electrode_metadata
-
-        # Set electrodes properties
-        recroding_extractor = recording_interface.recording_extractor
-        recroding_extractor.set_property(
-            key="brain_area",
-            values=electrode_metadata["Area"].values.tolist(),
-        )
-        recroding_extractor.set_property(
-            key="location",
-            values=electrode_metadata[["ML", "AP", "Z"]].values,
-        )
-
         # Rename unit properties to have descriptive names
         unit_properties_mapping = {
             "Area": "brain_area",
@@ -53,6 +39,7 @@ class AsapTdtNWBConverter(NWBConverter):
             B="good",
             C="not good enough to call single-unit",
         )
+        electrode_metadata = self.data_interface_objects["Recording"]._electrode_metadata
         electrode_metadata["Quality"] = electrode_metadata["Quality"].replace(quality_values_map)
         electrode_metadata["Quality (post-sorting)"] = electrode_metadata["Quality (post-sorting)"].replace(
             quality_values_map

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -27,69 +27,67 @@ class AsapTdtNWBConverter(NWBConverter):
 
         return metadata
 
+    def run_conversion(
+        self,
+        nwbfile_path: Optional[str] = None,
+        nwbfile: Optional[NWBFile] = None,
+        metadata: Optional[dict] = None,
+        overwrite: bool = False,
+        conversion_options: Optional[dict] = None,
+    ) -> None:
+        # Rename unit properties to have descriptive names
+        unit_properties_mapping = {
+            "Area": "brain_area",
+            "Quality": "unit_quality",
+            "Quality (post-sorting)": "unit_quality_post_sorting",
+            "GoodPeriod": "good_period",
+        }
 
-def run_conversion(
-    self,
-    nwbfile_path: Optional[str] = None,
-    nwbfile: Optional[NWBFile] = None,
-    metadata: Optional[dict] = None,
-    overwrite: bool = False,
-    conversion_options: Optional[dict] = None,
-) -> None:
+        # Map unit quality values to more descriptive names
+        quality_values_map = dict(
+            A="excellent",
+            B="good",
+            C="not good enough to call single-unit",
+        )
+        electrode_metadata = self.data_interface_objects["Recording"]._electrode_metadata
+        electrode_metadata["Quality"] = electrode_metadata["Quality"].replace(quality_values_map)
+        electrode_metadata["Quality (post-sorting)"] = electrode_metadata["Quality (post-sorting)"].replace(
+            quality_values_map
+        )
 
-    # Rename unit properties to have descriptive names
-    unit_properties_mapping = {
-        "Area": "brain_area",
-        "Quality": "unit_quality",
-        "Quality (post-sorting)": "unit_quality_post_sorting",
-        "GoodPeriod": "good_period",
-    }
+        num_units = 0
+        sorting_interfaces = [
+            interface_name for interface_name in self.data_interface_objects if "Sorting" in interface_name
+        ]
+        for interface_name in sorting_interfaces:
+            target_name = interface_name.replace("Sorting", "")
+            sorting_metadata = electrode_metadata[electrode_metadata["Target"] == target_name]
 
-    # Map unit quality values to more descriptive names
-    quality_values_map = dict(
-        A="excellent",
-        B="good",
-        C="not good enough to call single-unit",
-    )
-    electrode_metadata = self.data_interface_objects["Recording"]._electrode_metadata
-    electrode_metadata["Quality"] = electrode_metadata["Quality"].replace(quality_values_map)
-    electrode_metadata["Quality (post-sorting)"] = electrode_metadata["Quality (post-sorting)"].replace(
-        quality_values_map
-    )
+            sorting_interface = self.data_interface_objects[interface_name]
+            sorting_extractor = sorting_interface.sorting_extractor
 
-    num_units = 0
-    sorting_interfaces = [
-        interface_name for interface_name in self.data_interface_objects if "Sorting" in interface_name
-    ]
-    for interface_name in sorting_interfaces:
-        target_name = interface_name.replace("Sorting", "")
-        sorting_metadata = electrode_metadata[electrode_metadata["Target"] == target_name]
+            if len(sorting_metadata) != sorting_extractor.get_num_units():
+                # TODO: how to deal with the fact that the Vla data has 2 units but only one of them in the metadata
+                area_value = sorting_metadata["Area"].values[0]
+                sorting_extractor.set_property(
+                    key="brain_area",
+                    values=[area_value] * sorting_extractor.get_num_units(),
+                )
+                continue
+            for property_name, renamed_property_name in unit_properties_mapping.items():
+                sorting_extractor.set_property(
+                    key=renamed_property_name,
+                    values=sorting_metadata[property_name].values.tolist(),
+                )
+            extractor_unit_ids = sorting_extractor.get_unit_ids()
+            # unit_ids are not unique across sorting interfaces, so we are offsetting them here
+            sorting_extractor._main_ids = extractor_unit_ids + num_units
+            num_units = len(extractor_unit_ids)
 
-        sorting_interface = self.data_interface_objects[interface_name]
-        sorting_extractor = sorting_interface.sorting_extractor
-
-        if len(sorting_metadata) != sorting_extractor.get_num_units():
-            # TODO: how to deal with the fact that the Vla data has 2 units but only one of them in the metadata
-            area_value = sorting_metadata["Area"].values[0]
-            sorting_extractor.set_property(
-                key="brain_area",
-                values=[area_value] * sorting_extractor.get_num_units(),
-            )
-            continue
-        for property_name, renamed_property_name in unit_properties_mapping.items():
-            sorting_extractor.set_property(
-                key=renamed_property_name,
-                values=sorting_metadata[property_name].values.tolist(),
-            )
-        extractor_unit_ids = sorting_extractor.get_unit_ids()
-        # unit_ids are not unique across sorting interfaces, so we are offsetting them here
-        sorting_extractor._main_ids = extractor_unit_ids + num_units
-        num_units = len(extractor_unit_ids)
-
-    super().run_conversion(
-        nwbfile_path=nwbfile_path,
-        nwbfile=nwbfile,
-        metadata=metadata,
-        overwrite=overwrite,
-        conversion_options=conversion_options,
-    )
+        super().run_conversion(
+            nwbfile_path=nwbfile_path,
+            nwbfile=nwbfile,
+            metadata=metadata,
+            overwrite=overwrite,
+            conversion_options=conversion_options,
+        )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -1,0 +1,11 @@
+from neuroconv import NWBConverter
+
+from turner_lab_to_nwb.asap_tdt.interfaces import ASAPTdtRecordingInterface
+
+
+class AsapTdtNWBConverter(NWBConverter):
+    """Primary conversion class for my extracellular electrophysiology dataset."""
+
+    data_interface_classes = dict(
+        Recording=ASAPTdtRecordingInterface,
+    )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -52,6 +52,15 @@ class AsapTdtNWBConverter(NWBConverter):
 
             sorting_interface = self.data_interface_objects[interface_name]
             sorting_extractor = sorting_interface.sorting_extractor
+
+            if len(sorting_metadata) != sorting_extractor.get_num_units():
+                # TODO: how to deal with the fact that the Vla data has 2 units but only one of them in the metadata
+                area_value = sorting_metadata["Area"].values[0]
+                sorting_extractor.set_property(
+                    key="brain_area",
+                    values=[area_value] * sorting_extractor.get_num_units(),
+                )
+                continue
             for property_name, renamed_property_name in unit_properties_mapping.items():
                 sorting_extractor.set_property(
                     key=renamed_property_name,

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -8,7 +8,7 @@ from turner_lab_to_nwb.asap_tdt.interfaces import ASAPTdtRecordingInterface
 
 
 class AsapTdtNWBConverter(NWBConverter):
-    """Primary conversion class for my extracellular electrophysiology dataset."""
+    """Primary conversion class for Turner's extracellular electrophysiology dataset."""
 
     data_interface_classes = dict(
         Recording=ASAPTdtRecordingInterface,

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/__init__.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/__init__.py
@@ -1,0 +1,1 @@
+from .asap_tdt_recordinginterface import ASAPTdtRecordingInterface

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
@@ -113,20 +113,3 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
         )
 
         return metadata
-
-
-#
-# interface = ASAPTdtRecordingInterface(
-#     file_path="/Users/weian/data/Previous_PD_Project_sample/I_160615/Gaia_I_160615_1.tev",
-#     electrode_metadata_file_path="/Users/weian/data/Previous_PD_Project_sample/Isis_DataList_160615.xlsx"
-# )
-# metadata = interface.get_metadata()
-# metadata["NWBFile"].update(session_start_time=datetime.utcnow())
-# interface.run_conversion(nwbfile_path="test.nwb", metadata=metadata, stub_test=True, overwrite=True)
-#
-# from pynwb import NWBHDF5IO
-
-# io=NWBHDF5IO("test.nwb", "r")
-# nwbfile = io.read()
-#
-# print("x")

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 import pandas as pd
 from neuroconv.datainterfaces.ecephys.baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -77,6 +78,10 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
     def get_metadata(self) -> dict:
         metadata = super().get_metadata()
 
+        metadata["NWBFile"].update(
+            session_start_time=datetime.strptime(str(self._electrode_metadata["Date"][0]), "%y%m%d"),
+        )
+
         ecephys_metadata = metadata["Ecephys"]
         device_metadata = ecephys_metadata["Device"][0]
         device_metadata.update(
@@ -101,6 +106,10 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
             # SpikeInterface refers to this as 'brain_area', NeuroConv remaps to 'location'
             key="brain_area",
             values=self._electrode_metadata["Area"].values.tolist(),
+        )
+        self.recording_extractor.set_property(
+            key="location",
+            values=self._electrode_metadata[["ML", "AP", "Z"]].values,
         )
 
         # Add electrodes and electrode groups

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
@@ -24,6 +24,8 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
         ----------
         file_path : FilePathType
             The path to the TDT recording file.
+        electrode_metadata_file_path : FilePathType
+            The path to the TDT electrode metadata file.
         stream_id : FilePathType
             The stream of the data for spikeinterface, "3" by default.
         verbose : bool, default: True

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
@@ -48,8 +48,8 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
 
         # Tungsten electrode on channel 1 (channels 2-15 were grounded)
         # 16ch V-probe (tip-first contact length: 500 µm, inter-contact-interval: 150 µm) on channels 17-32
-        channel_ids = list(parent_recording.get_channel_ids())
-        sliced_channel_ids = [channel_ids[0]] + channel_ids[-16:]
+        # Note the channel map can be different from session to session
+        sliced_channel_ids = electrode_metadata["Chan#"].astype(str).values.tolist()
         super().__init__(
             parent_recording=parent_recording, channel_ids=sliced_channel_ids, verbose=verbose, es_key=es_key
         )

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
@@ -79,7 +79,7 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
         metadata = super().get_metadata()
 
         metadata["NWBFile"].update(
-            session_start_time=datetime.strptime(str(self._electrode_metadata["Date"][0]), "%y%m%d"),
+            session_start_time=datetime.strptime(str(self._electrode_metadata["Date"].values[0]), "%y%m%d"),
         )
 
         ecephys_metadata = metadata["Ecephys"]

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 import pandas as pd
 from neuroconv.datainterfaces.ecephys.baserecordingextractorinterface import BaseRecordingExtractorInterface
@@ -7,7 +6,6 @@ from spikeinterface import ChannelSliceRecording
 
 
 class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
-
     Extractor = ChannelSliceRecording
 
     def __init__(
@@ -41,7 +39,8 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
             f"The file {file_path} is not a valid TDT file." f"The file suffix must be one of {valid_suffices}."
         )
 
-        self._electrode_metadata = self._load_electrode_metadata(file_path=electrode_metadata_file_path)
+        electrode_metadata = self.load_electrode_metadata(file_path=electrode_metadata_file_path)
+        self._electrode_metadata = electrode_metadata.drop_duplicates(subset=["Chan#"])
         parent_recording = TdtRecordingExtractor(
             folder_path=str(self.file_path), stream_id=stream_id, all_annotations=True
         )
@@ -65,7 +64,7 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
         channel_names = [name.replace("'", "")[1:] for name in channel_names]
         self.recording_extractor.set_property(key="channel_name", values=channel_names)
 
-    def _load_electrode_metadata(self, file_path: FilePathType):
+    def load_electrode_metadata(self, file_path: FilePathType):
         """Load the electrode metadata from the Excel file."""
         electrodes_metadata = pd.read_excel(file_path)
         # filter for this session

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+from pathlib import Path
+import pandas as pd
+from neuroconv.datainterfaces.ecephys.baserecordingextractorinterface import BaseRecordingExtractorInterface
+from neuroconv.utils import FilePathType
+from spikeinterface import ChannelSliceRecording
+
+
+class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
+
+    Extractor = ChannelSliceRecording
+
+    def __init__(
+        self,
+        file_path: FilePathType,
+        electrode_metadata_file_path: FilePathType,
+        stream_id: str = "3",
+        verbose: bool = True,
+        es_key: str = "ElectricalSeries",
+    ):
+        """
+        Load and prepare raw data and corresponding metadata from the TDT format (.Tbk files).
+
+        Parameters
+        ----------
+        file_path : FilePathType
+            The path to the TDT recording file.
+        stream_id : FilePathType
+            The stream of the data for spikeinterface, "3" by default.
+        verbose : bool, default: True
+            Verbose
+        es_key : str, default: "ElectricalSeries"
+        """
+        from spikeinterface.extractors import TdtRecordingExtractor
+
+        self.file_path = Path(file_path)
+
+        assert self.file_path.exists(), f"The file {file_path} does not exist."
+        valid_suffices = [".Tbk", ".Tdx", ".tev", ".tnt", ".tsq"]
+        assert self.file_path.suffix in valid_suffices, (
+            f"The file {file_path} is not a valid TDT file." f"The file suffix must be one of {valid_suffices}."
+        )
+
+        self._electrode_metadata = self._load_electrode_metadata(file_path=electrode_metadata_file_path)
+        parent_recording = TdtRecordingExtractor(
+            folder_path=str(self.file_path), stream_id=stream_id, all_annotations=True
+        )
+
+        # Tungsten electrode on channel 1 (channels 2-15 were grounded)
+        # 16ch V-probe (tip-first contact length: 500 µm, inter-contact-interval: 150 µm) on channels 17-32
+        channel_ids = list(parent_recording.get_channel_ids())
+        sliced_channel_ids = [channel_ids[0]] + channel_ids[-16:]
+        super().__init__(
+            parent_recording=parent_recording, channel_ids=sliced_channel_ids, verbose=verbose, es_key=es_key
+        )
+
+        # Set properties
+        group_names = "Group " + self._electrode_metadata["Target"]
+        self.recording_extractor.set_property(key="group_name", ids=sliced_channel_ids, values=group_names)
+        custom_names = self._electrode_metadata.apply(lambda row: f"{row['Electrode']}-{row['Chan#']}", axis=1).tolist()
+        self.recording_extractor.set_property(key="custom_channel_name", ids=sliced_channel_ids, values=custom_names)
+
+        # Fix channel name format
+        channel_names = self.recording_extractor.get_property("channel_name")
+        channel_names = [name.replace("'", "")[1:] for name in channel_names]
+        self.recording_extractor.set_property(key="channel_name", values=channel_names)
+
+    def _load_electrode_metadata(self, file_path: FilePathType):
+        """Load the electrode metadata from the Excel file."""
+        electrodes_metadata = pd.read_excel(file_path)
+        # filter for this session
+        _, filename = self.file_path.stem.split("_", maxsplit=1)
+        electrode_metadata = electrodes_metadata[electrodes_metadata["Filename"] == filename]
+        # todo: how to handle duplicated channel numbers? (e.g. channel 21 is duplicated)
+        electrode_metadata_without_duplicates = electrode_metadata.drop_duplicates(subset=["Chan#"])
+        return electrode_metadata_without_duplicates
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+
+        ecephys_metadata = metadata["Ecephys"]
+        device_metadata = ecephys_metadata["Device"][0]
+        device_metadata.update(
+            description="TDT recording",
+            manufacturer="Tucker-Davis Technologies (TDT)",
+        )
+
+        electrode_groups = []
+        unique_electrodes_data = self._electrode_metadata.groupby("Area").first()
+        for location, data in unique_electrodes_data.iterrows():
+            electrode_groups.append(
+                dict(
+                    name=f'Group {data["Target"]}',
+                    description=f"Group {data['Electrode']} electrodes.",
+                    device=ecephys_metadata["Device"][0]["name"],
+                    location=location,
+                )
+            )
+        ecephys_metadata.update(ElectrodeGroup=electrode_groups)
+
+        self.recording_extractor.set_property(
+            # SpikeInterface refers to this as 'brain_area', NeuroConv remaps to 'location'
+            key="brain_area",
+            values=self._electrode_metadata["Area"].values.tolist(),
+        )
+
+        # Add electrodes and electrode groups
+        ecephys_metadata.update(
+            Electrodes=[
+                dict(name="group_name", description="The name of the ElectrodeGroup this electrode is a part of."),
+                dict(name="custom_channel_name", description="Custom channel name assigned in TDT."),
+            ]
+        )
+
+        return metadata
+
+
+#
+# interface = ASAPTdtRecordingInterface(
+#     file_path="/Users/weian/data/Previous_PD_Project_sample/I_160615/Gaia_I_160615_1.tev",
+#     electrode_metadata_file_path="/Users/weian/data/Previous_PD_Project_sample/Isis_DataList_160615.xlsx"
+# )
+# metadata = interface.get_metadata()
+# metadata["NWBFile"].update(session_start_time=datetime.utcnow())
+# interface.run_conversion(nwbfile_path="test.nwb", metadata=metadata, stub_test=True, overwrite=True)
+#
+# from pynwb import NWBHDF5IO
+
+# io=NWBHDF5IO("test.nwb", "r")
+# nwbfile = io.read()
+#
+# print("x")

--- a/src/turner_lab_to_nwb/asap_tdt/utils/__init__.py
+++ b/src/turner_lab_to_nwb/asap_tdt/utils/__init__.py
@@ -1,0 +1,1 @@
+from .load_data_list import load_session_metadata

--- a/src/turner_lab_to_nwb/asap_tdt/utils/load_data_list.py
+++ b/src/turner_lab_to_nwb/asap_tdt/utils/load_data_list.py
@@ -1,0 +1,11 @@
+import pandas as pd
+from neuroconv.utils import FilePathType
+
+
+def load_session_metadata(file_path: FilePathType, session_id: str):
+    """Load the session metadata from the Excel file."""
+    electrodes_metadata = pd.read_excel(file_path)
+    # filter for this session
+    electrode_metadata = electrodes_metadata[electrodes_metadata["Filename"] == session_id]
+    electrode_metadata_without_duplicates = electrode_metadata.drop_duplicates(subset=["Chan#"])
+    return electrode_metadata_without_duplicates


### PR DESCRIPTION
Add TDT recording pipeline:

- Raw acquisition traces from GPi and VLa are added from TDT (Tucker-Davis Technologies) files (see Initial notes #3)
- Spike sorting output from Plexon is added to ecephys processing module
- Conversion script that converts a single session
- Conversion script that converts all sessions that are available

In a follow up I'll add:
- Filtered ecephys traces that are saved in separate .mat files (GPi, VL traces are saved separately)
- With respect to https://github.com/catalystneuro/neuroconv/issues/540, Once we received the correct gain for the raw traces, I'll make the adjustment to Neuroconv to propagate gain to fix the conversion factor, which is currently 1. 

