### PR TITLE
Add TDT events

### DIFF
--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_all_sessions.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_all_sessions.py
@@ -62,6 +62,10 @@ for index, metadata in enumerate(metadata_list):
         # If stimulation site is GPi, we only have spike sorting date from VL region, the plexon file for GPi is empty
         gpi_plexon_file_path = None
 
+    events_file_path = folder_path / f"I_{date_string}" / f"{session_id}.mat"
+    # The mapping of the target identifiers to more descriptive names, e.g. 1: "Left", 3: "Right"
+    target_name_mapping = {1: "Left", 3: "Right"}
+
     session_to_nwb(
         tdt_tank_file_path=metadata["source_data"]["recording"]["file_path"],
         nwbfile_path=output_dir_path / nwbfile_name,
@@ -69,5 +73,7 @@ for index, metadata in enumerate(metadata_list):
         vl_plexon_file_path=vl_plexon_file_path,
         gpi_plexon_file_path=gpi_plexon_file_path,
         session_id=session_id,
+        events_file_path=events_file_path,
+        target_name_mapping=target_name_mapping,
         stub_test=stub_test,
     )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -14,7 +14,9 @@ def session_to_nwb(
     data_list_file_path: FilePathType,
     vl_plexon_file_path: FilePathType,
     session_id: str,
+    events_file_path: FilePathType,
     gpi_plexon_file_path: Optional[FilePathType] = None,
+    target_name_mapping: Optional[dict] = None,
     stub_test: bool = False,
 ):
     """
@@ -34,6 +36,10 @@ def session_to_nwb(
         The path to Plexon file (.plx) containing the spike sorted data from GPi.
     session_id : str
         The unique identifier for the session.
+    events_file_path : FilePathType
+        The path that points to the .mat file containing the events, units data and optionally include the stimulation data.
+    target_name_mapping : Optional[dict], optional
+        A dictionary mapping the target identifiers to more descriptive names, e.g. 1: "Left", 3: "Right".
     stub_test : bool, optional
         Whether to run the conversion in stub test mode, by default False.
     """
@@ -59,6 +65,11 @@ def session_to_nwb(
     if gpi_plexon_file_path:
         source_data.update(dict(SortingGPi=dict(file_path=str(gpi_plexon_file_path))))
         conversion_options.update(dict(SortingGPi=conversion_options_sorting))
+
+    # Add Events
+    source_data.update(dict(Events=dict(file_path=str(events_file_path))))
+    if target_name_mapping:
+        conversion_options.update(dict(Events=dict(target_name_mapping=target_name_mapping)))
 
     converter = AsapTdtNWBConverter(source_data=source_data)
 
@@ -104,7 +115,12 @@ if __name__ == "__main__":
     # The plexon file with the spike sorted data from GPi, optional
     # When stimulation site is GPi, the plexon file is empty and this should be set to None
     # gpi_plexon_file_path = None
-    gpi_plexon_file_path = folder_path / f"I_{date_string}" / f"{session_id}_Chans_24_24.plx"
+    gpi_plexon_file_path = folder_path / f"I_{date_string}" / f"{session_id}_Chans_17_32.plx"
+
+    # The path to the .mat file containing the events, units data and optionally include the stimulation data
+    events_file_path = folder_path / f"I_{date_string}" / f"{session_id}.mat"
+    # The mapping of the target identifiers to more descriptive names, e.g. 1: "Left", 3: "Right"
+    target_name_mapping = {1: "Left", 3: "Right"}
 
     # The path to the NWB file to be created
     nwbfile_path = Path(f"/Volumes/t7-ssd/nwbfiles/stub_Gaia_{session_id}.nwb")
@@ -119,5 +135,7 @@ if __name__ == "__main__":
         vl_plexon_file_path=vl_plexon_file_path,
         gpi_plexon_file_path=gpi_plexon_file_path,
         session_id=session_id,
+        events_file_path=events_file_path,
+        target_name_mapping=target_name_mapping,
         stub_test=stub_test,
     )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_requirements.txt
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_requirements.txt
@@ -1,2 +1,3 @@
 neuroconv[tdt,plexon]
 openpyxl==3.1.2
+ndx-events==0.2.0

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from neuroconv import NWBConverter
 from neuroconv.datainterfaces import PlexonSortingInterface
+from neuroconv.tools.nwb_helpers import get_default_backend_configuration, configure_backend
 from neuroconv.utils import DeepDict
 from pynwb import NWBFile
 
@@ -27,6 +28,12 @@ class AsapTdtNWBConverter(NWBConverter):
         metadata["NWBFile"].update(session_start_time=interface_metadata["NWBFile"]["session_start_time"])
 
         return metadata
+
+    def add_to_nwbfile(self, nwbfile: NWBFile, metadata, conversion_options: Optional[dict] = None) -> None:
+        super().add_to_nwbfile(nwbfile=nwbfile, metadata=metadata, conversion_options=conversion_options)
+
+        backend_configuration = get_default_backend_configuration(nwbfile=nwbfile, backend="hdf5")
+        configure_backend(nwbfile=nwbfile, backend_configuration=backend_configuration)
 
     def run_conversion(
         self,

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -29,12 +29,6 @@ class AsapTdtNWBConverter(NWBConverter):
 
         return metadata
 
-    def add_to_nwbfile(self, nwbfile: NWBFile, metadata, conversion_options: Optional[dict] = None) -> None:
-        super().add_to_nwbfile(nwbfile=nwbfile, metadata=metadata, conversion_options=conversion_options)
-
-        backend_configuration = get_default_backend_configuration(nwbfile=nwbfile, backend="hdf5")
-        configure_backend(nwbfile=nwbfile, backend_configuration=backend_configuration)
-
     def run_conversion(
         self,
         nwbfile_path: Optional[str] = None,

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -85,6 +85,12 @@ class AsapTdtNWBConverter(NWBConverter):
             sorting_extractor._main_ids = extractor_unit_ids + num_units
             num_units = len(extractor_unit_ids)
 
+        # Add stimulation events metadata
+        stimulation_site = electrode_metadata["Stim. site"].unique()[0]
+        if stimulation_site:
+            stimulation_depth = electrode_metadata["Stim. depth"].unique()[0]
+            metadata["StimulationEvents"].update(stimulation_site=stimulation_site, stimulation_depth=stimulation_depth)
+
         super().run_conversion(
             nwbfile_path=nwbfile_path,
             nwbfile=nwbfile,

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -5,7 +5,7 @@ from neuroconv.datainterfaces import PlexonSortingInterface
 from neuroconv.utils import DeepDict
 from pynwb import NWBFile
 
-from turner_lab_to_nwb.asap_tdt.interfaces import ASAPTdtRecordingInterface
+from turner_lab_to_nwb.asap_tdt.interfaces import ASAPTdtRecordingInterface, ASAPTdtEventsInterface
 
 
 class AsapTdtNWBConverter(NWBConverter):
@@ -15,14 +15,15 @@ class AsapTdtNWBConverter(NWBConverter):
         Recording=ASAPTdtRecordingInterface,
         SortingVL=PlexonSortingInterface,
         SortingGPi=PlexonSortingInterface,
+        Events=ASAPTdtEventsInterface,
     )
 
     def get_metadata(self) -> DeepDict:
         metadata = super().get_metadata()
 
-        # Explicitly set session_start_time to recording start time
-        recording_interface = self.data_interface_objects["Recording"]
-        interface_metadata = recording_interface.get_metadata()
+        # Explicitly set session_start_time to the start time from events interface (most accurate)
+        events_interface = self.data_interface_objects["Events"]
+        interface_metadata = events_interface.get_metadata()
         metadata["NWBFile"].update(session_start_time=interface_metadata["NWBFile"]["session_start_time"])
 
         return metadata

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -87,7 +87,7 @@ class AsapTdtNWBConverter(NWBConverter):
             num_units = len(extractor_unit_ids)
 
         # Add stimulation events metadata
-        stimulation_site = electrode_metadata["Stim. site"].unique()[0]
+        stimulation_site = electrode_metadata["Stim. site"].replace(np.nan, None).unique()[0]
         if stimulation_site:
             stimulation_depth = electrode_metadata["Stim. depth"].unique()[0]
             metadata["StimulationEvents"].update(stimulation_site=stimulation_site, stimulation_depth=stimulation_depth)

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/__init__.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/__init__.py
@@ -1,1 +1,2 @@
 from .asap_tdt_recordinginterface import ASAPTdtRecordingInterface
+from .asap_tdt_eventsinterface import ASAPTdtEventsInterface

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_eventsinterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_eventsinterface.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from neuroconv import BaseDataInterface
+from neuroconv.utils import FilePathType, DeepDict
+from pymatreader import read_mat
+from pynwb import NWBFile
+
+
+class ASAPTdtEventsInterface(BaseDataInterface):
+    """Events interface for asap_tdt conversion"""
+
+    keywords = ["behavior"]
+
+    def __init__(self, file_path: FilePathType, verbose: bool = False):
+        """
+        Parameters
+        ----------
+        file_path : FilePathType
+            The path that points to the .mat file containing the events, units data and optionally include the stimulation data.
+        """
+        file_path = Path(file_path)
+        assert file_path.exists(), f"File {file_path} does not exist."
+        self.file_path = file_path
+        self.verbose = verbose
+        self._events_data = read_mat(filename=str(self.file_path))
+
+    def get_metadata(self) -> DeepDict:
+        metadata = super().get_metadata()
+
+        # Convert “TankSummary.CollectDate” as the days from Jan/1/1900 to datetime timestamp
+        start_date = datetime(1900, 1, 1)
+        assert (
+            "Tanksummary" in self._events_data
+        ), "The 'Tanksummary' structure is not in the file. The start time of the session cannot be determined."
+        assert (
+            "CollectDate" in self._events_data["Tanksummary"]
+        ), "The 'CollectDate' field is not in the 'Tanksummary' structure. The start time of the session cannot be determined."
+        days_from_start_date = self._events_data["Tanksummary"]["CollectDate"]
+        days_timedelta = timedelta(days=days_from_start_date)
+        session_start_time = start_date + days_timedelta
+        metadata["NWBFile"].update(session_start_time=session_start_time)
+
+        return metadata
+
+    def add_trials(self, nwbfile: NWBFile, target_name_mapping: Optional[dict] = None):
+        """
+        Add trials to the nwbfile
+
+        Parameters
+        ----------
+        nwbfile : NWBFile
+            The nwbfile to add the trials to.
+        target_name_mapping : Optional[dict], optional
+            A dictionary mapping the target identifiers to more descriptive names, e.g. 1: "Left", 3: "Right".
+        """
+
+        event_structure_name = "events"
+        assert event_structure_name in self._events_data, f"The '{event_structure_name}' structure is not in the file."
+        events = self._events_data[event_structure_name]
+
+        for trial_start_time, trial_stop_time in zip(events["starttime"], events["endtime"]):
+            nwbfile.add_trial(
+                start_time=trial_start_time,
+                stop_time=trial_stop_time,
+            )
+
+        # Use more descriptive names for the event types
+        event_names_mapping = dict(
+            erroron="error_onset",
+            rewardon="reward_start_time",
+            rewardoff="reward_stop_time",
+            mvt_onset="movement_start_time",
+            mvt_end="movement_stop_time",
+            return_onset="return_start_time",
+            return_end="return_stop_time",
+            cue_onset="cue_onset",
+        )
+        events_description_mapping = dict(
+            erroron="The times of the error onset.",
+            rewardon="The times of the reward onset.",
+            rewardoff="The times of the reward offset.",
+            mvt_onset="The times of the hand sensor at the home-position off (= onset of the movement).",
+            mvt_end="The times of the hand sensor at the reach target on (= end of the movement).",
+            return_onset="The times of the hand sensor at the reach target off (= onset of the return movement)",
+            return_end="The times of the hand sensor at the home-position on (= end of the return movement)",
+            cue_onset="The times of the target and go-cue instruction (reach target and go-cue were instructed simulatneously in this task).",
+        )
+
+        for event_name, mapped_event_name in event_names_mapping.items():
+            nwbfile.add_trial_column(
+                name=mapped_event_name,
+                description=events_description_mapping[event_name],
+                data=events[event_name],
+            )
+
+        target_data = events["target"].astype(int)
+        if target_name_mapping is not None:
+            target_data = [target_name_mapping[t] for t in target_data]
+        nwbfile.add_trial_column(
+            name="target",
+            description="Defines whether the target was on the left or right side.",
+            data=target_data,
+        )
+
+    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict, target_name_mapping: Optional[dict] = None):
+        self.add_trials(nwbfile=nwbfile, target_name_mapping=target_name_mapping)


### PR DESCRIPTION
Add events data from .mat file to `nwbfile.trials`
Some sessions also include "dbs" structure in the .mat file, this structure contains the stimulation onset times.
The stimulation data is added as `AnnotatedEventsTable` from `ndx-events` where we also add the stimulation site and depth metadata

[Notes about events data](https://github.com/catalystneuro/turner-lab-to-nwb/blob/aae711ea5c18e9b5cf5528d2efd7e2ded963d399/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md)