### PR TITLE
Add curated units

### DIFF
--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -54,17 +54,28 @@ def session_to_nwb(
     )
     conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
 
-    # Add Sorting
-    source_data.update(dict(SortingVL=dict(file_path=str(vl_plexon_file_path))))
+    # Add Sorting (uncurated spike times from Plexon Offline Sorter v3)
+    source_data.update(dict(PlexonSortingVL=dict(file_path=str(vl_plexon_file_path))))
     conversion_options_sorting = dict(
         stub_test=stub_test,
         write_as="processing",
         units_description="The units were sorted using the Plexon Offline Sorter v3.",
     )
-    conversion_options.update(dict(SortingVL=conversion_options_sorting))
+    conversion_options.update(dict(PlexonSortingVL=conversion_options_sorting))
     if gpi_plexon_file_path:
-        source_data.update(dict(SortingGPi=dict(file_path=str(gpi_plexon_file_path))))
-        conversion_options.update(dict(SortingGPi=conversion_options_sorting))
+        source_data.update(dict(PlexonSortingGPi=dict(file_path=str(gpi_plexon_file_path))))
+        conversion_options.update(dict(PlexonSortingGPi=conversion_options_sorting))
+
+    # Add Sorting (curated spike times from Plexon Offline Sorter v3, only include single units)
+    source_data.update(dict(CuratedSorting=dict(file_path=str(events_file_path))))
+    conversion_options.update(
+        dict(
+            CuratedSorting=dict(
+                stub_test=stub_test,
+                units_description="The curated single-units from the Plexon Offline Sorter v3, selected based on the quality of spike sorting.",
+            )
+        )
+    )
 
     # Add Events
     source_data.update(dict(Events=dict(file_path=str(events_file_path))))

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_metadata.yaml
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_metadata.yaml
@@ -13,3 +13,7 @@ Ecephys:
       description: The quality of the unit after sorting.
     - name: good_period
       description: The period when the spike waveforms had good isolation.
+    - name: channel_ids
+      description: The electrode channel ids for each unit.
+    - name: label
+      description: The sorting label for each unit.

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -63,7 +63,7 @@ class AsapTdtNWBConverter(NWBConverter):
             # set unit properties
             area_value = sorting_metadata["Area"].values[0]
             sorting_extractor.set_property(
-                key="brain_area",
+                key="location",
                 values=[area_value] * sorting_extractor.get_num_units(),
             )
             extractor_unit_ids = sorting_extractor.get_unit_ids()

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -7,6 +7,7 @@ from neuroconv.utils import DeepDict
 from pynwb import NWBFile
 
 from turner_lab_to_nwb.asap_tdt.interfaces import ASAPTdtRecordingInterface, ASAPTdtEventsInterface
+from turner_lab_to_nwb.asap_tdt.interfaces.asap_tdt_sortinginterface import ASAPTdtSortingInterface
 
 
 class AsapTdtNWBConverter(NWBConverter):
@@ -14,8 +15,9 @@ class AsapTdtNWBConverter(NWBConverter):
 
     data_interface_classes = dict(
         Recording=ASAPTdtRecordingInterface,
-        SortingVL=PlexonSortingInterface,
-        SortingGPi=PlexonSortingInterface,
+        PlexonSortingVL=PlexonSortingInterface,
+        PlexonSortingGPi=PlexonSortingInterface,
+        CuratedSorting=ASAPTdtSortingInterface,
         Events=ASAPTdtEventsInterface,
     )
 
@@ -43,50 +45,27 @@ class AsapTdtNWBConverter(NWBConverter):
         overwrite: bool = False,
         conversion_options: Optional[dict] = None,
     ) -> None:
-        # Rename unit properties to have descriptive names
-        unit_properties_mapping = {
-            "Area": "brain_area",
-            "Quality": "unit_quality",
-            "Quality (post-sorting)": "unit_quality_post_sorting",
-            "GoodPeriod": "good_period",
-        }
 
-        # Map unit quality values to more descriptive names
-        quality_values_map = dict(
-            A="excellent",
-            B="good",
-            C="not good enough to call single-unit",
-        )
+        # Add unit properties
         electrode_metadata = self.data_interface_objects["Recording"]._electrode_metadata
-        electrode_metadata["Quality"] = electrode_metadata["Quality"].replace(quality_values_map)
-        electrode_metadata["Quality (post-sorting)"] = electrode_metadata["Quality (post-sorting)"].replace(
-            quality_values_map
-        )
 
         num_units = 0
-        sorting_interfaces = [
-            interface_name for interface_name in self.data_interface_objects if "Sorting" in interface_name
+        plexon_sorting_interfaces = [
+            interface_name for interface_name in self.data_interface_objects if "PlexonSorting" in interface_name
         ]
-        for interface_name in sorting_interfaces:
-            target_name = interface_name.replace("Sorting", "")
+        for interface_name in plexon_sorting_interfaces:
+            target_name = interface_name.replace("PlexonSorting", "")
             sorting_metadata = electrode_metadata[electrode_metadata["Target"] == target_name]
 
             sorting_interface = self.data_interface_objects[interface_name]
             sorting_extractor = sorting_interface.sorting_extractor
 
-            if len(sorting_metadata) != sorting_extractor.get_num_units():
-                # TODO: how to deal with the fact that the Vla data has 2 units but only one of them in the metadata
-                area_value = sorting_metadata["Area"].values[0]
-                sorting_extractor.set_property(
-                    key="brain_area",
-                    values=[area_value] * sorting_extractor.get_num_units(),
-                )
-                continue
-            for property_name, renamed_property_name in unit_properties_mapping.items():
-                sorting_extractor.set_property(
-                    key=renamed_property_name,
-                    values=sorting_metadata[property_name].values.tolist(),
-                )
+            # set unit properties
+            area_value = sorting_metadata["Area"].values[0]
+            sorting_extractor.set_property(
+                key="brain_area",
+                values=[area_value] * sorting_extractor.get_num_units(),
+            )
             extractor_unit_ids = sorting_extractor.get_unit_ids()
             # unit_ids are not unique across sorting interfaces, so we are offsetting them here
             sorting_extractor._main_ids = extractor_unit_ids + num_units

--- a/src/turner_lab_to_nwb/asap_tdt/extractors/__init__.py
+++ b/src/turner_lab_to_nwb/asap_tdt/extractors/__init__.py
@@ -1,0 +1,1 @@
+from .asap_tdt_sortingextractor import ASAPTdtSortingExtractor

--- a/src/turner_lab_to_nwb/asap_tdt/extractors/asap_tdt_sortingextractor.py
+++ b/src/turner_lab_to_nwb/asap_tdt/extractors/asap_tdt_sortingextractor.py
@@ -1,0 +1,81 @@
+from typing import Optional
+import numpy as np
+from pymatreader import read_mat
+from spikeinterface import BaseSorting, BaseSortingSegment
+
+from neuroconv.utils import FilePathType
+
+
+class ASAPTdtSortingExtractor(BaseSorting):
+    extractor_name = "ASAPTdtSorting"
+    installed = True
+    mode = "file"
+    installation_mesg = ""
+    name = "tdtsorting"
+
+    def __init__(self, file_path: FilePathType):
+        """
+        Parameters
+        ----------
+        file_path : FilePathType
+            The file path to the MAT file containing the clustered spike times.
+        """
+
+        mat = read_mat(file_path)
+        assert "units" in mat, f"The 'units' structure is missing from '{file_path}'."
+        self._units_data = mat["units"]
+        spike_times = self._units_data["ts"]
+        num_units = len(self._units_data["uname"])
+        unit_ids = np.arange(num_units)
+
+        sampling_frequency = float(mat["Tanksummary"]["ChanFS"][-1])
+
+        BaseSorting.__init__(self, sampling_frequency=sampling_frequency, unit_ids=unit_ids)
+        sorting_segment = ASAPTdtSortingSegment(
+            sampling_frequency=sampling_frequency,
+            spike_times=spike_times,
+        )
+        self.add_sorting_segment(sorting_segment)
+
+        # Map unit quality values to more descriptive names
+        quality_values_map = {
+            "A": "excellent",
+            "B": "good",
+            "A -> B": "changed to good from excellent based on post-sorting quality",
+            "B -> A": "changed to excellent from good based on post-sorting quality",
+        }
+        units_quality = [quality_values_map.get(quality, quality) for quality in self._units_data["sort_qual"]]
+        self.set_property(key="unit_quality_post_sorting", values=units_quality)
+
+        unit_properties_mapping = dict(
+            uname="unit_name",
+            sort="sort_label",
+            brain_area="brain_area",
+            chan="channel_ids",
+        )
+        for property_name, renamed_property_name in unit_properties_mapping.items():
+            self.set_property(
+                key=renamed_property_name,
+                values=self._units_data[property_name],
+            )
+
+
+class ASAPTdtSortingSegment(BaseSortingSegment):
+    def __init__(self, sampling_frequency: float, spike_times: np.ndarray):
+        BaseSortingSegment.__init__(self)
+        self._spike_times = spike_times
+        self._sampling_frequency = sampling_frequency
+
+    def get_unit_spike_train(
+        self,
+        unit_id: int,
+        start_frame: Optional[int] = None,
+        end_frame: Optional[int] = None,
+    ) -> np.ndarray:
+        times = self._spike_times[unit_id]
+        frames = (times * self._sampling_frequency).astype(int)
+        if start_frame is not None:
+            frames = frames[frames >= start_frame]
+        if end_frame is not None:
+            frames = frames[frames < end_frame]
+        return frames

--- a/src/turner_lab_to_nwb/asap_tdt/extractors/asap_tdt_sortingextractor.py
+++ b/src/turner_lab_to_nwb/asap_tdt/extractors/asap_tdt_sortingextractor.py
@@ -50,7 +50,7 @@ class ASAPTdtSortingExtractor(BaseSorting):
         unit_properties_mapping = dict(
             uname="unit_name",
             sort="sort_label",
-            brain_area="brain_area",
+            brain_area="location",
             chan="channel_ids",
         )
         for property_name, renamed_property_name in unit_properties_mapping.items():

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_sortinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_sortinginterface.py
@@ -1,0 +1,19 @@
+from neuroconv.datainterfaces.ecephys.basesortingextractorinterface import BaseSortingExtractorInterface
+from neuroconv.utils import FilePathType
+
+from turner_lab_to_nwb.asap_tdt.extractors import ASAPTdtSortingExtractor
+
+
+class ASAPTdtSortingInterface(BaseSortingExtractorInterface):
+    Extractor = ASAPTdtSortingExtractor
+
+    def __init__(self, file_path: FilePathType, verbose: bool = True):
+        """
+        Parameters
+        ----------
+        file_path: FilePathType
+            Path to the MAT file containing the spiking data.
+        verbose: bool, default: True
+            Allows verbosity.
+        """
+        super().__init__(file_path=file_path, verbose=verbose)


### PR DESCRIPTION
Add `ASAPTdtSortingInterface` to write `units` from .mat file and add unit properties ("unit_name", "brain_area", ... channel_ids) see snippet:

<img width="500" alt="Screenshot 2024-01-11 at 17 38 53 (2)" src="https://github.com/catalystneuro/turner-lab-to-nwb/assets/24475788/7f015ea5-bd64-44d9-811d-a506068d3ced">

- The processed units table contains the "location" (Brain area is the meaning of location in the nwb standard), but the other properties have been removed for now since we have them for the main units table
