### PR TITLE
Add subject metadata

### DIFF
--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_all_sessions.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_all_sessions.py
@@ -69,5 +69,6 @@ for index, metadata in enumerate(metadata_list):
         vl_plexon_file_path=vl_plexon_file_path,
         gpi_plexon_file_path=gpi_plexon_file_path,
         session_id=session_id,
+        subject_id=subject_id,
         stub_test=stub_test,
     )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -120,6 +120,8 @@ def session_to_nwb(
     subject_metadata_path = Path(__file__).parent / "asap_tdt_subjects_metadata.yaml"
     subject_metadata = load_dict_from_file(subject_metadata_path)
     assert subject_id in subject_metadata["Subject"], f"Subject {subject_id} is not in the metadata file."
+    pharmacology = subject_metadata["Subject"][subject_id].pop("pharmacology")
+    metadata["NWBFile"].update(pharmacology=pharmacology)
     metadata["Subject"] = subject_metadata["Subject"][subject_id]
 
     # Run conversion

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -14,6 +14,7 @@ def session_to_nwb(
     data_list_file_path: FilePathType,
     vl_plexon_file_path: FilePathType,
     session_id: str,
+    subject_id: str,
     gpi_plexon_file_path: Optional[FilePathType] = None,
     stub_test: bool = False,
 ):
@@ -34,6 +35,8 @@ def session_to_nwb(
         The path to Plexon file (.plx) containing the spike sorted data from GPi.
     session_id : str
         The unique identifier for the session.
+    subject_id : str
+        The unique identifier for the subject.
     stub_test : bool, optional
         Whether to run the conversion in stub test mode, by default False.
     """
@@ -77,6 +80,12 @@ def session_to_nwb(
     editable_metadata = load_dict_from_file(editable_metadata_path)
     metadata = dict_deep_update(metadata, editable_metadata)
 
+    # Load subject metadata from the yaml file
+    subject_metadata_path = Path(__file__).parent / "asap_tdt_subjects_metadata.yaml"
+    subject_metadata = load_dict_from_file(subject_metadata_path)
+    assert subject_id in subject_metadata["Subject"], f"Subject {subject_id} is not in the metadata file."
+    metadata["Subject"] = subject_metadata["Subject"][subject_id]
+
     # Run conversion
     converter.run_conversion(
         metadata=metadata, nwbfile_path=nwbfile_path, conversion_options=conversion_options, overwrite=True
@@ -93,8 +102,11 @@ if __name__ == "__main__":
     # The identifier of the session to be converted
     session_id = f"I_{date_string}_2"
 
+    # The identifier of the subject
+    subject_id = "Gaia"
+
     # The path to a single TDT Tank file (.Tbk)
-    tank_file_path = folder_path / f"I_{date_string}" / f"Gaia_{session_id}.Tbk"
+    tank_file_path = folder_path / f"I_{date_string}" / f"{subject_id}_{session_id}.Tbk"
 
     # The path to the electrode metadata file (.xlsx)
     data_list_file_path = Path("/Volumes/t7-ssd/Turner/Previous_PD_Project_sample/Isis_DataList_temp.xlsx")
@@ -107,7 +119,7 @@ if __name__ == "__main__":
     gpi_plexon_file_path = folder_path / f"I_{date_string}" / f"{session_id}_Chans_24_24.plx"
 
     # The path to the NWB file to be created
-    nwbfile_path = Path(f"/Volumes/t7-ssd/nwbfiles/stub_Gaia_{session_id}.nwb")
+    nwbfile_path = Path(f"/Volumes/t7-ssd/nwbfiles/stub_{subject_id}_{session_id}.nwb")
 
     # For testing purposes, set stub_test to True to convert only a stub of the session
     stub_test = False
@@ -119,5 +131,6 @@ if __name__ == "__main__":
         vl_plexon_file_path=vl_plexon_file_path,
         gpi_plexon_file_path=gpi_plexon_file_path,
         session_id=session_id,
+        subject_id=subject_id,
         stub_test=stub_test,
     )

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_notes.md
@@ -65,6 +65,19 @@ The events data is stored in `.mat` files (in a structure called `events`).
 Some sessions may also include stimulation data which is stored in `.mat` files (in a structure called `dbs`).
 This data contains the onset times of stimulation. The site of stimulation and depth is stored in the `DataList` spreadsheet ("Stim. depth", "Stim. site").
 
+## Subject metadata
+
+The subject metadata can be provided in the `asap_tdt_subject_metadata.yaml` file as the follows:
+
+```yaml
+Subject:
+  {subject_id}:
+    species: Macaca mulatta # The formal latin binomal name for the species of the subject
+    subject_id: {subject_id} # The unique identifier of the subject
+    date_of_birth: 2009-01-01
+    sex: F # F, M or U for unknown
+```
+
 ## TDT to NWB mapping
 
 TODO: add UML diagram

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_subjects_metadata.yaml
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_subjects_metadata.yaml
@@ -1,14 +1,15 @@
 Subject:
   Gaia:
     subject_id: Gaia
-    description: USDA# RQ7431, MPTP administration 2/9/15 (internal carotid artery injection)
+    description: USDA registration number RQ7431
+    pharmacology: MPTP (1-methyl-4-phenyl-1,2,3,6-tetrahydropyridine; the chemical compound that induces parkinsonism) administration date 2015-02-09 (ICA; internal carotid artery injection)
     species: Macaca mulatta # Rhesus monkey
     sex: F
     date_of_birth: 2005-02-01
   Isis:
     subject_id: Isis
-    description: |
-      USDA# RQ7513, MPTP administration 10/27/17 (ICA, internal carotid artery injection), 11/28/17 (IM, intramuscular injection), 12/01/17 (IM), 6/8/18 (ICA), 7/5/18 (IM), 7/19/18 (IM), 8/27/18 (IM)
+    description: USDA registration number RQ7513
+    pharmacology: MPTP (1-methyl-4-phenyl-1,2,3,6-tetrahydropyridine; the chemical compound that induces parkinsonism) administration date 2017-10-27 (ICA; internal carotid artery injection), 2017-11-28 (IM; intramuscular injection), 2017-12-01 (IM), 2018-06-08 (ICA), 2018-07-05 (IM), 2018-07-19 (IM), 2018-08-27 (IM)
     date_of_birth: 2005-06-14
     sex: F
     species: Macaca mulatta # Rhesus monkey

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_subjects_metadata.yaml
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_subjects_metadata.yaml
@@ -1,0 +1,14 @@
+Subject:
+  Gaia:
+    subject_id: Gaia
+    description: USDA# RQ7431, MPTP administration 2/9/15 (internal carotid artery injection)
+    species: Macaca mulatta # Rhesus monkey
+    sex: F
+    date_of_birth: 2005-02-01
+  Isis:
+    subject_id: Isis
+    description: |
+      USDA# RQ7513, MPTP administration 10/27/17 (ICA, internal carotid artery injection), 11/28/17 (IM, intramuscular injection), 12/01/17 (IM), 6/8/18 (ICA), 7/5/18 (IM), 7/19/18 (IM), 8/27/18 (IM)
+    date_of_birth: 2005-06-14
+    sex: F
+    species: Macaca mulatta # Rhesus monkey


### PR DESCRIPTION
Add subject metadata to NWB

- The subject metadata can be provided in the `asap_tdt_subject_metadata.yaml` file as the follows:

 ```yaml
 Subject:
   {subject_id}:
     species: Macaca mulatta # The formal latin binomal name for the species of the subject
     subject_id: {subject_id} # The unique identifier of the subject
     date_of_birth: 2009-01-01
     sex: F # F, M or U for unknown
 ```

