### PR TITLE
Add `gain` to `ASAPTdtRecordingInterface`

### DIFF
--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdt_convert_session.py
@@ -56,7 +56,7 @@ def session_to_nwb(
 
     # Add Recording
     source_data.update(
-        dict(Recording=dict(file_path=str(ecephys_file_path), data_list_file_path=str(data_list_file_path)))
+        dict(Recording=dict(file_path=str(ecephys_file_path), data_list_file_path=str(data_list_file_path), gain=1.0))
     )
     conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
 
@@ -157,7 +157,7 @@ if __name__ == "__main__":
     nwbfile_path = Path(f"/Volumes/t7-ssd/nwbfiles/stub_Gaia_{session_id}.nwb")
 
     # For testing purposes, set stub_test to True to convert only a stub of the session
-    stub_test = False
+    stub_test = True
 
     session_to_nwb(
         nwbfile_path=nwbfile_path,

--- a/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
+++ b/src/turner_lab_to_nwb/asap_tdt/asap_tdtnwbconverter.py
@@ -82,7 +82,6 @@ class AsapTdtNWBConverter(NWBConverter):
     ) -> None:
         # Add unit properties
         electrode_metadata = self.data_interface_objects["Recording"]._electrode_metadata
-        # self.data_interface_objects["Recording"].recording_extractor.set_channel_gains(1.0)
 
         # Set processed recording interface properties to match with raw recording interface
         vl_interface_name = "ProcessedRecordingVL"

--- a/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
+++ b/src/turner_lab_to_nwb/asap_tdt/interfaces/asap_tdt_recordinginterface.py
@@ -14,6 +14,7 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
         self,
         file_path: FilePathType,
         data_list_file_path: FilePathType,
+        gain: float,
         stream_id: str = "3",
         verbose: bool = True,
         es_key: str = "ElectricalSeries",
@@ -27,6 +28,8 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
             The path to the TDT recording file.
         data_list_file_path : FilePathType
             The path that points to the electrode metadata file (.xlsx).
+        gain : float
+            The conversion factor from int16 to microvolts.
         stream_id : FilePathType
             The stream of the data for spikeinterface, "3" by default.
         verbose : bool, default: True
@@ -49,6 +52,8 @@ class ASAPTdtRecordingInterface(BaseRecordingExtractorInterface):
         parent_recording = TdtRecordingExtractor(
             folder_path=str(self.file_path), stream_id=stream_id, all_annotations=True
         )
+        # Set "gain_to_uV" extractor property
+        parent_recording.set_channel_gains(gain)
 
         # Tungsten electrode on channel 1 (channels 2-15 were grounded)
         # 16ch V-probe (tip-first contact length: 500 µm, inter-contact-interval: 150 µm) on channels 17-32


### PR DESCRIPTION
Add `gain` as a required property to `ASAPTdtRecordingInterface`:

Previously, the  `gain_to_uV` SI extractor property was `1e6` which resulted in an incorrect conversion factor of 1.
See #6 , also https://github.com/NeuralEnsemble/python-neo/issues/1369

Here we set the gain to `1.0`, so the `conversion` factor of the raw and processed ElectricalSeries data will be `0.000001`.
